### PR TITLE
Bootstrap repository for structured AI glossary

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- Describe the issue or new term request. -->
+
+## Term or topic
+
+- **Proposed term:**
+- **Category:** <!-- e.g., LLM Core, Governance, Ops -->
+
+## Why it matters
+
+<!-- Briefly explain the motivation, user need, or risk being addressed. -->
+
+## Suggested sources
+
+<!-- List credible sources such as Google ML Glossary, Hugging Face, NIST AI RMF, etc. -->
+
+## Additional context
+
+<!-- Any other notes, links, or blockers. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+
+- [ ] Adds or updates **one** term under `data/terms/`
+- [ ] Includes at least one citation from a reputable source
+- [ ] Updates status, governance tags, and examples as needed
+
+## Validation
+
+- [ ] `make validate`
+- [ ] `python scripts/build_index.py`
+- [ ] `cd site && mkdocs build`
+
+## Additional context
+
+<!-- Add notes for reviewers, links to discussions, or risk considerations. -->

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,53 @@
+name: Build Release Artifacts
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate glossary entries
+        run: make validate
+
+      - name: Generate JSON outputs
+        run: python scripts/build_index.py --data-dir data/terms --output-dir build
+
+      - name: Build MkDocs site
+        run: |
+          cd site
+          mkdocs build --strict
+
+      - name: Upload glossary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: glossary-json
+          path: build/glossary.json
+
+      - name: Upload search index
+        uses: actions/upload-artifact@v4
+        with:
+          name: search-index
+          path: build/search-index.json
+
+      - name: Upload static site
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: site/site

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,34 @@
+name: Validate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate glossary entries
+        run: make validate
+
+      - name: Build JSON outputs
+        run: python scripts/build_index.py --data-dir data/terms --output-dir build
+
+      - name: Build documentation site
+        run: |
+          cd site
+          mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+build/
+site/site/
+.DS_Store

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default reviewers for all files
+* @your-org/ai-glossary-maintainers
+
+# Content buckets
+schema/ @your-org/ai-glossary-architecture
+scripts/ @your-org/ai-glossary-architecture
+site/ @your-org/ai-glossary-docs
+api/ @your-org/ai-glossary-platform

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT EMAIL ADDRESS]. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTENT_LICENSE
+++ b/CONTENT_LICENSE
@@ -1,0 +1,24 @@
+Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+=======================================================================
+
+The textual content of the AI Glossary (including all files in `data/terms/` and
+supporting documentation derived from those files) is licensed under the
+Creative Commons Attribution-ShareAlike 4.0 International License.
+
+You are free to:
+
+- **Share** — copy and redistribute the material in any medium or format.
+- **Adapt** — remix, transform, and build upon the material for any purpose,
+  even commercially.
+
+Under the following terms:
+
+- **Attribution** — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any reasonable
+  manner, but not in any way that suggests the licensor endorses you or your use.
+- **ShareAlike** — If you remix, transform, or build upon the material, you must
+  distribute your contributions under the same license as the original.
+- **No additional restrictions** — You may not apply legal terms or technological
+  measures that legally restrict others from doing anything the license permits.
+
+Full license text: https://creativecommons.org/licenses/by-sa/4.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to the AI Glossary
+
+Thank you for helping build a high-quality, shared vocabulary for AI.
+
+## Ground rules
+
+- Be respectful and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+- Open an issue before large or controversial changes.
+- Keep PRs focused: add or update **one term** (or a closely related set of
+  metadata files) per pull request.
+- Provide at least **one reputable citation** for every definition.
+- Prefer paraphrasing over copying. All contributions are shared under
+  [CC BY-SA 4.0](CONTENT_LICENSE).
+
+## Workflow
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the validation suite before committing:
+   ```bash
+   make validate
+   ```
+4. Regenerate JSON outputs when adding or updating terms:
+   ```bash
+   python scripts/build_index.py
+   ```
+5. Commit changes with clear messages and open a pull request using the
+   provided template.
+
+## Authoring a term
+
+All term files live in `data/terms/` and must:
+
+- Be named after the canonical term (kebab-case), e.g., `retrieval-augmented-generation.yml`.
+- Match the schema defined in `schema/term.schema.json`.
+- Include:
+  - `short_def` (≤40 words, plain language)
+  - `long_def` (120–200 words, structured paragraphs welcome)
+  - `audiences.exec` and `audiences.engineer`
+  - At least one `examples.do` entry and one `examples.dont` entry
+  - Governance notes (`nist_rmf_tags`, `risk_notes`) when applicable
+  - `citations` with `source` and `url`
+  - `status` lifecycle field (`draft`, `reviewed`, `approved`, `deprecated`)
+- Use inclusive language and avoid marketing claims.
+
+## Review checklist
+
+Reviewers use the following checklist:
+
+- [ ] Schema validation succeeds (`make validate`).
+- [ ] `short_def` <= 40 words and is free of jargon.
+- [ ] `long_def` provides necessary context (120–200 words).
+- [ ] Executive and engineering explanations are present and audience-appropriate.
+- [ ] Examples illustrate correct and incorrect usage.
+- [ ] At least one credible citation is provided.
+- [ ] NIST RMF tags or risk notes supplied when relevant.
+- [ ] No obvious copy/paste without attribution.
+
+## Questions?
+
+Open a [discussion](https://github.com/your-org/ai-glossary/discussions) or reach
+out via issues if you are unsure about anything.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 AI Glossary Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+PYTHON ?= python3
+DATA_DIR := data/terms
+
+.PHONY: validate build serve-api serve-docs
+
+validate:
+	$(PYTHON) scripts/validate.py --data-dir $(DATA_DIR)
+
+build:
+	$(PYTHON) scripts/build_index.py --data-dir $(DATA_DIR)
+
+serve-api:
+	uvicorn api.main:app --reload
+
+serve-docs:
+	cd site && mkdocs serve

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# ai-glossary
+# AI Glossary
+
+An open, living glossary that bridges product, engineering, and governance language for artificial intelligence systems. Each term is stored as structured data so it can power documentation, APIs, and downstream tools.
+
+## Project goals
+
+- Harmonize terminology used by product, engineering, and policy teams.
+- Capture sourcing, examples, and governance context for every term.
+- Provide audience-aware definitions (executive and engineering perspectives).
+- Publish content as both a static site and machine-readable datasets.
+
+## Repository layout
+
+```
+ai-glossary/
+  README.md
+  LICENSE
+  CONTENT_LICENSE
+  CONTRIBUTING.md
+  CODE_OF_CONDUCT.md
+  schema/term.schema.json
+  data/terms/
+    ... individual YAML entries ...
+  scripts/
+    validate.py
+    build_index.py
+  site/
+    mkdocs.yml
+    docs/
+      index.md
+  api/
+    main.py
+  .github/
+    workflows/
+      validate.yml
+      build_release.yml
+    ISSUE_TEMPLATE.md
+    PULL_REQUEST_TEMPLATE.md
+  Makefile
+  requirements.txt
+```
+
+## Getting started
+
+1. Create and activate a Python 3.10+ virtual environment.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Validate all glossary entries:
+   ```bash
+   make validate
+   ```
+4. Regenerate JSON outputs after editing entries:
+   ```bash
+   python scripts/build_index.py
+   ```
+
+The MkDocs site (in `site/`) and FastAPI service (in `api/`) consume the YAML files generated under `data/terms/`.
+
+## Data model
+
+Each term file under `data/terms/` must satisfy `schema/term.schema.json`. Highlights:
+
+- `term`: canonical name that should match the filename.
+- `aliases`: alternative spellings or related expressions.
+- `short_def`: ≤40-word description for broad audiences.
+- `audiences.exec` and `audiences.engineer`: tailored explanations.
+- `examples.do` / `examples.dont`: positive and negative illustrations.
+- `governance`: risk-related notes and NIST RMF tags when applicable.
+- `citations`: at least one reputable source with URL.
+- `status`: lifecycle state (`draft`, `reviewed`, `approved`, `deprecated`).
+
+## Governance
+
+- Contributions must follow the [Contributor Covenant](CODE_OF_CONDUCT.md).
+- Every PR should modify a single term (or add a new one) and include citations.
+- Automated checks enforce schema compliance, lint rules, and documentation builds.
+
+## Roadmap
+
+- **v0.1** – 50 core LLM and governance terms with MkDocs site & JSON index.
+- **v0.2** – 120+ terms, NIST RMF crosswalks, improved search metadata.
+- **v0.3** – Hosted API, embeddable widget, automated synonym suggestions.
+
+## License
+
+- Code is provided under the [MIT License](LICENSE).
+- Content (YAML term files) is provided under [CC BY-SA 4.0](CONTENT_LICENSE).

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,78 @@
+"""FastAPI service that serves glossary terms from YAML files."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, List
+
+import sys
+
+CURRENT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CURRENT_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from fastapi import FastAPI, HTTPException
+
+from glossary_utils import safe_load_path
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data" / "terms"
+
+app = FastAPI(
+    title="AI Glossary API",
+    description="Lightweight API that exposes glossary entries maintained in YAML files.",
+    version="0.1.0",
+)
+
+
+def normalize_term(term: str) -> str:
+    slug = term.strip().lower().replace(" ", "-").replace("_", "-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug
+
+
+@lru_cache(maxsize=1)
+def _load_terms() -> Dict[str, dict]:
+    terms: Dict[str, dict] = {}
+    for path in sorted(DATA_DIR.glob("*.yml")):
+        data = safe_load_path(path) or {}
+        slug = normalize_term(data.get("term", path.stem))
+        data["slug"] = slug
+        data["_source_file"] = str(path)
+        terms[slug] = data
+    return terms
+
+
+def _terms_list() -> List[dict]:
+    return list(_load_terms().values())
+
+
+@app.get("/", tags=["metadata"])
+def read_root() -> dict:
+    return {
+        "name": "AI Glossary",
+        "description": "Structured, citation-backed AI glossary",
+        "count": len(_load_terms()),
+    }
+
+
+@app.get("/terms", tags=["terms"])
+def list_terms() -> List[dict]:
+    return _terms_list()
+
+
+@app.get("/terms/{slug}", tags=["terms"])
+def get_term(slug: str) -> dict:
+    term = _load_terms().get(slug)
+    if not term:
+        raise HTTPException(status_code=404, detail="Term not found")
+    return term
+
+
+@app.post("/refresh", tags=["metadata"], response_model=dict)
+def refresh_terms() -> dict:
+    _load_terms.cache_clear()  # type: ignore[attr-defined]
+    refreshed = len(_load_terms())
+    return {"refreshed": refreshed}

--- a/data/terms/hallucination.yml
+++ b/data/terms/hallucination.yml
@@ -1,0 +1,55 @@
+term: "hallucination"
+aliases:
+  - "AI hallucination"
+  - "confabulation"
+part_of_speech: "noun"
+short_def: "When an AI model presents fabricated or unsupported information as fact."
+long_def: >-
+  Hallucination describes the tendency of generative models to deliver content that sounds
+  plausible but is either factually incorrect, logically inconsistent, or entirely invented.
+  The phenomenon stems from the probabilistic way large language models predict the next
+  token based on training data patterns rather than grounded knowledge of the world. It can
+  occur when prompts lack sufficient context, when the model has not seen relevant examples
+  during training, or when decoding strategies over-index on fluency instead of accuracy.
+  Product teams experience hallucination as broken user trust, while engineers may notice it
+  during evaluation as high lexical overlap paired with low factual precision. Mitigations
+  range from retrieval augmentation and prompt constraints to post-generation fact checking,
+  human review, and model fine-tuning on verified corpora. Organizations must treat
+  hallucination as both a quality and a risk management issue, particularly in regulated or
+  safety-critical workflows.
+audiences:
+  exec: "Signals that the model is making things up, which erodes user trust and can trigger compliance issues."
+  engineer: "Indicates the model sampled a high-probability sequence lacking factual grounding; investigate context, decoding, and eval signals."
+examples:
+  do:
+    - "Log hallucination incidents and route high-severity cases to human review for remediation."
+    - "Use retrieval augmentation or tool grounding to supply verifiable context before generation."
+  dont:
+    - "Deploy long-form responses without monitoring factual accuracy or adding disclaimers."
+    - "Assume higher model size alone will eliminate hallucination without evaluation improvements."
+governance:
+  nist_rmf_tags:
+    - "accuracy"
+    - "transparency"
+    - "validity"
+  risk_notes: "Unaddressed hallucinations can produce misleading outputs that violate accuracy commitments and create legal exposure."
+relationships:
+  broader:
+    - "generative AI"
+  narrower:
+    - "factual hallucination"
+    - "formal hallucination"
+  related:
+    - "retrieval-augmented generation"
+    - "guardrails"
+    - "evaluation"
+citations:
+  - source: "Hugging Face Glossary"
+    url: "https://huggingface.co/docs/transformers/en/glossary"
+  - source: "NIST AI RMF Glossary"
+    url: "https://airc.nist.gov/glossary/"
+  - source: "Google ML Glossary"
+    url: "https://developers.google.com/machine-learning/glossary"
+license: "CC BY-SA 4.0"
+status: "draft"
+last_reviewed: "2024-09-18"

--- a/data/terms/quantization.yml
+++ b/data/terms/quantization.yml
@@ -1,0 +1,55 @@
+term: "quantization"
+aliases:
+  - "model quantization"
+  - "weight quantization"
+part_of_speech: "process"
+short_def: "Technique that compresses model weights into lower-precision formats to shrink size and speed inference."
+long_def: >-
+  Quantization converts neural network parameters and activations from high-precision floating
+  point representations (such as FP32) into lower bit-width formats (such as INT8 or INT4) to
+  reduce memory footprint and accelerate inference. By mapping continuous values into a discrete
+  set, quantization enables models to run on cost-sensitive hardware, deliver faster responses,
+  and consume less energy, which is critical when deploying large language models at scale or on
+  edge devices. Engineers choose between post-training quantization, which calibrates a frozen
+  model on representative data, and quantization-aware training, which simulates low-precision
+  behavior during fine-tuning to preserve accuracy. Careful evaluation is required to understand
+  the trade-offs: aggressive quantization can introduce numerical instability, harm latency
+  determinism, or amplify bias if calibration data under-represents certain groups. Successful
+  programs pair quantization with monitoring, backstops such as higher-precision fallbacks, and
+  documentation that makes these trade-offs explicit to stakeholders.
+audiences:
+  exec: "A cost-control lever: shrink model footprints so you can serve more traffic on existing hardware."
+  engineer: "Apply per-tensor or per-channel scaling, choose symmetric/asymmetric schemes, and validate perplexity and latency post-quantization."
+examples:
+  do:
+    - "Benchmark accuracy and latency before and after quantization to document the trade-offs."
+    - "Use representative calibration datasets that include edge cases and demographic variation."
+  dont:
+    - "Quantize safety-critical models without fallback paths or runtime monitoring."
+    - "Assume INT4 settings will work across architectures without profiling."
+governance:
+  nist_rmf_tags:
+    - "efficiency"
+    - "robustness"
+    - "documentation"
+  risk_notes: "Quantization can reduce accuracy or shift error distribution; record evaluations and obtain stakeholder sign-off."
+relationships:
+  broader:
+    - "model optimization"
+  narrower:
+    - "post-training quantization"
+    - "quantization-aware training"
+  related:
+    - "compression"
+    - "distillation"
+    - "hardware acceleration"
+citations:
+  - source: "Google ML Glossary"
+    url: "https://developers.google.com/machine-learning/glossary"
+  - source: "Hugging Face Glossary"
+    url: "https://huggingface.co/docs/transformers/en/glossary"
+  - source: "Stanford HAI Brief Definitions"
+    url: "https://hai.stanford.edu/news/brief-definitions"
+license: "CC BY-SA 4.0"
+status: "draft"
+last_reviewed: "2024-09-18"

--- a/data/terms/retrieval-augmented-generation.yml
+++ b/data/terms/retrieval-augmented-generation.yml
@@ -1,0 +1,57 @@
+term: "retrieval-augmented generation"
+aliases:
+  - "RAG"
+  - "retrieval augmented generation"
+part_of_speech: "process"
+short_def: "Workflow that grounds a generative model with retrieved context before producing output."
+long_def: >-
+  Retrieval-augmented generation (RAG) combines information retrieval and text generation so
+  that a model answers questions using relevant, up-to-date context instead of only relying on
+  patterns memorized during pretraining. A retrieval component first decomposes the user query
+  and searches a corpus—via sparse, dense, or hybrid methods—to surface the most relevant
+  passages. Those passages are then packaged, often alongside metadata like source citations,
+  and injected into the model prompt or context window prior to decoding. The approach reduces
+  hallucinations, improves factual accuracy, and enables small models to compete with larger
+  ones when grounded knowledge is more important than general fluency. Successful RAG systems
+  invest in document chunking, embedding quality, reranking, and evaluation pipelines that
+  monitor both retrieval recall and answer precision. Governance teams value RAG because it
+  enables transparent sourcing and can encode organizational policies in the retrieval layer,
+  but they also monitor for drift, stale content, and privacy leaks when sensitive documents are
+  indexed.
+audiences:
+  exec: "Treat it as a guardrail: the system fetches trusted documents before the model speaks, so answers stay on-policy."
+  engineer: "Pipeline = query rewriting, retriever (BM25, DPR, hybrid), reranker, and generator with retrieved context appended to the prompt."
+examples:
+  do:
+    - "Version and monitor the document index so you can trace outputs back to specific sources."
+    - "Evaluate retrieval recall and answer accuracy separately to isolate failure modes."
+  dont:
+    - "Assume RAG removes the need for model fine-tuning or ongoing evaluation."
+    - "Index sensitive records without access controls or data minimization."
+governance:
+  nist_rmf_tags:
+    - "transparency"
+    - "data_quality"
+    - "documentation"
+  risk_notes: "Requires controls for stale data, source governance, and privacy when indexing internal corpora."
+relationships:
+  broader:
+    - "grounded generation"
+  narrower:
+    - "hybrid RAG"
+    - "agentic RAG"
+  related:
+    - "retrieval"
+    - "chunking"
+    - "reranking"
+    - "hallucination"
+citations:
+  - source: "Hugging Face Glossary"
+    url: "https://huggingface.co/docs/transformers/en/glossary"
+  - source: "Google ML Glossary"
+    url: "https://developers.google.com/machine-learning/glossary"
+  - source: "Wikipedia AI Glossary"
+    url: "https://en.wikipedia.org/wiki/Glossary_of_artificial_intelligence"
+license: "CC BY-SA 4.0"
+status: "draft"
+last_reviewed: "2024-09-18"

--- a/glossary_utils/__init__.py
+++ b/glossary_utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers shared across the AI Glossary project."""
+
+from .simple_yaml import safe_load, safe_load_path
+
+__all__ = ["safe_load", "safe_load_path"]

--- a/glossary_utils/simple_yaml.py
+++ b/glossary_utils/simple_yaml.py
@@ -1,0 +1,179 @@
+"""Minimal YAML loader for the glossary project.
+
+This parser handles the limited subset of YAML used in `data/terms/`:
+- dictionaries with string keys
+- lists of scalars or dictionaries
+- double-quoted or plain string values
+- folded block scalars introduced by `>-`
+
+The implementation is intentionally small so the project can run in
+restricted environments without external dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List
+
+
+@dataclass
+class SimpleYAMLParser:
+    lines: List[str]
+    base_indent: int = 0
+    index: int = 0
+
+    @classmethod
+    def from_text(cls, text: str, base_indent: int = 0) -> "SimpleYAMLParser":
+        lines = [line.rstrip("\n") for line in text.splitlines()]
+        return cls(lines=lines, base_indent=base_indent, index=0)
+
+    def parse(self) -> Any:
+        return self.parse_block(0)
+
+    def parse_block(self, indent: int) -> Any:
+        while self.index < len(self.lines):
+            line = self.lines[self.index]
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                self.index += 1
+                continue
+            current_indent = self.get_indent(line)
+            if current_indent < indent:
+                break
+            if stripped.startswith("- "):
+                return self.parse_sequence(indent)
+            return self.parse_mapping(indent)
+        return {}
+
+    def parse_mapping(self, indent: int) -> dict:
+        result: dict = {}
+        while self.index < len(self.lines):
+            line = self.lines[self.index]
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                self.index += 1
+                continue
+            current_indent = self.get_indent(line)
+            if current_indent < indent or stripped.startswith("- "):
+                break
+            if ":" not in stripped:
+                raise ValueError(f"Unsupported YAML mapping line: {line}")
+            key, rest = stripped.split(":", 1)
+            key = key.strip()
+            rest = rest.strip()
+            self.index += 1
+
+            if rest in {">", ">-"}:
+                value = self.parse_folded_block(indent)
+            elif rest == "":
+                value = self.parse_block(indent + 2)
+            else:
+                value = parse_scalar(rest)
+            result[key] = value
+        return result
+
+    def parse_sequence(self, indent: int) -> list:
+        result: list = []
+        while self.index < len(self.lines):
+            line = self.lines[self.index]
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                self.index += 1
+                continue
+            current_indent = self.get_indent(line)
+            if current_indent < indent or not stripped.startswith("- "):
+                break
+            item_content = stripped[2:]
+            self.index += 1
+
+            if item_content == "":
+                value = self.parse_block(indent + 2)
+            elif ":" in item_content and not item_content.strip().startswith(('"', "'")):
+                value = self.parse_nested_item(indent, item_content)
+            else:
+                value = parse_scalar(item_content)
+            result.append(value)
+        return result
+
+    def parse_nested_item(self, indent: int, first_line: str) -> Any:
+        item_lines: List[str] = [" " * (self.base_indent + indent + 2) + first_line]
+        while self.index < len(self.lines):
+            next_line = self.lines[self.index]
+            stripped = next_line.strip()
+            if not stripped:
+                item_lines.append(next_line)
+                self.index += 1
+                continue
+            next_indent = self.get_indent(next_line)
+            if next_indent <= indent:
+                break
+            item_lines.append(next_line)
+            self.index += 1
+        sub_parser = SimpleYAMLParser(item_lines, base_indent=self.base_indent + indent + 2)
+        return sub_parser.parse_block(0)
+
+    def parse_folded_block(self, indent: int) -> str:
+        lines: List[str] = []
+        while self.index < len(self.lines):
+            line = self.lines[self.index]
+            stripped = line.strip("\n")
+            if not stripped:
+                lines.append("")
+                self.index += 1
+                continue
+            if self.get_indent(line) < indent + 2:
+                break
+            trimmed = line[self.base_indent + indent + 2 :]
+            lines.append(trimmed.rstrip())
+            self.index += 1
+        paragraphs: List[str] = []
+        current: List[str] = []
+        for segment in lines:
+            if segment.strip() == "":
+                if current:
+                    paragraphs.append(" ".join(part.strip() for part in current).strip())
+                    current = []
+            else:
+                current.append(segment)
+        if current:
+            paragraphs.append(" ".join(part.strip() for part in current).strip())
+        return "\n\n".join(paragraphs)
+
+    def get_indent(self, line: str) -> int:
+        return max(0, self.absolute_indent(line) - self.base_indent)
+
+    @staticmethod
+    def absolute_indent(line: str) -> int:
+        return len(line) - len(line.lstrip(" "))
+
+
+def parse_scalar(text: str) -> Any:
+    text = text.strip()
+    if not text:
+        return ""
+    if text.startswith('"') and text.endswith('"'):
+        return text[1:-1].replace('\\"', '"')
+    if text.startswith("'") and text.endswith("'"):
+        return text[1:-1]
+    lowered = text.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    if lowered in {"null", "none", "~"}:
+        return None
+    if text.isdigit():
+        return int(text)
+    try:
+        return float(text)
+    except ValueError:
+        return text
+
+
+def safe_load(text: str) -> Any:
+    parser = SimpleYAMLParser.from_text(text)
+    return parser.parse()
+
+
+def safe_load_path(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return safe_load(handle.read())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.2
+uvicorn[standard]==0.29.0
+PyYAML==6.0.1
+jsonschema==4.22.0
+mkdocs==1.5.3
+mkdocs-material==9.5.15
+jinja2==3.1.4

--- a/schema/term.schema.json
+++ b/schema/term.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI Glossary Term",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "term",
+    "aliases",
+    "part_of_speech",
+    "short_def",
+    "long_def",
+    "audiences",
+    "examples",
+    "governance",
+    "relationships",
+    "citations",
+    "license",
+    "status",
+    "last_reviewed"
+  ],
+  "properties": {
+    "term": {
+      "type": "string",
+      "minLength": 1
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "part_of_speech": {
+      "type": "string",
+      "enum": [
+        "noun",
+        "noun_phrase",
+        "verb",
+        "adjective",
+        "process",
+        "concept"
+      ]
+    },
+    "short_def": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 320
+    },
+    "long_def": {
+      "type": "string",
+      "minLength": 1
+    },
+    "audiences": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["exec", "engineer"],
+      "properties": {
+        "exec": { "type": "string", "minLength": 1 },
+        "engineer": { "type": "string", "minLength": 1 }
+      }
+    },
+    "examples": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["do", "dont"],
+      "properties": {
+        "do": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        },
+        "dont": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1
+        }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "nist_rmf_tags": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "risk_notes": {
+          "type": "string"
+        }
+      }
+    },
+    "relationships": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "broader": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "narrower": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "related": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "citations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source", "url"],
+        "properties": {
+          "source": { "type": "string", "minLength": 1 },
+          "url": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "license": {
+      "type": "string",
+      "enum": ["CC BY-SA 4.0"]
+    },
+    "status": {
+      "type": "string",
+      "enum": ["draft", "reviewed", "approved", "deprecated"]
+    },
+    "last_reviewed": {
+      "type": "string",
+      "format": "date"
+    }
+  }
+}

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -1,0 +1,84 @@
+"""Build aggregated JSON files from glossary YAML entries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import sys
+
+CURRENT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CURRENT_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from glossary_utils import safe_load_path
+
+
+def load_terms(data_dir: Path) -> List[Dict[str, Any]]:
+    terms: List[Dict[str, Any]] = []
+    for path in sorted(data_dir.glob("*.yml")):
+        data = safe_load_path(path) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected mapping in {path}")
+        data["_source_file"] = str(path)
+        terms.append(data)
+    return terms
+
+
+def build_search_index(terms: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    index: List[Dict[str, Any]] = []
+    for entry in terms:
+        index.append(
+            {
+                "term": entry.get("term"),
+                "aliases": entry.get("aliases", []),
+                "short_def": entry.get("short_def"),
+                "nist_rmf_tags": entry.get("governance", {}).get("nist_rmf_tags", []),
+                "status": entry.get("status"),
+            }
+        )
+    return index
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build JSON outputs from glossary data")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data/terms"),
+        help="Directory containing YAML term files",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("build"),
+        help="Directory for generated JSON files",
+    )
+    args = parser.parse_args()
+
+    terms = load_terms(args.data_dir)
+    if not terms:
+        raise SystemExit(f"No term files found in {args.data_dir}")
+
+    glossary_payload = {"terms": terms}
+    search_payload = build_search_index(terms)
+
+    write_json(args.output_dir / "glossary.json", glossary_payload)
+    write_json(args.output_dir / "search-index.json", search_payload)
+
+    print(
+        f"Wrote {len(terms)} term(s) to {args.output_dir / 'glossary.json'} and search index."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,212 @@
+"""Validate glossary term files against custom rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+CURRENT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = CURRENT_DIR.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from glossary_utils import safe_load_path
+
+SCHEMA_PATH = Path("schema/term.schema.json")
+ALLOWED_PARTS_OF_SPEECH = {"noun", "noun_phrase", "verb", "adjective", "process", "concept"}
+ALLOWED_STATUSES = {"draft", "reviewed", "approved", "deprecated"}
+ALLOWED_LICENSES = {"CC BY-SA 4.0"}
+MAX_SHORT_DEF_WORDS = 40
+MIN_LONG_DEF_WORDS = 80
+MAX_LONG_DEF_WORDS = 220
+
+
+def load_required_fields() -> List[str]:
+    with SCHEMA_PATH.open("r", encoding="utf-8") as handle:
+        schema = json.load(handle)
+    return schema.get("required", [])
+
+
+def normalize_term(term: str) -> str:
+    slug = term.strip().lower().replace(" ", "-").replace("_", "-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    return slug
+
+
+def count_words(text: str) -> int:
+    return len([word for word in text.split() if word.strip()])
+
+
+def ensure_list_of_strings(value, *, allow_empty: bool = False) -> bool:
+    if not isinstance(value, list):
+        return False
+    if not allow_empty and len(value) == 0:
+        return False
+    return all(isinstance(item, str) and item.strip() for item in value)
+
+
+def validate_file(path: Path, required_fields: List[str]) -> List[str]:
+    errors: List[str] = []
+    data = safe_load_path(path)
+
+    if not isinstance(data, dict):
+        return [f"{path}: top-level YAML must define a mapping"]
+
+    for field in required_fields:
+        if field not in data:
+            errors.append(f"{path}: missing required field '{field}'")
+
+    term = data.get("term")
+    if isinstance(term, str):
+        if normalize_term(term) != path.stem.lower():
+            errors.append(
+                f"{path}: term '{term}' should match filename slug '{path.stem.lower()}'"
+            )
+    else:
+        errors.append(f"{path}: 'term' must be a string")
+
+    aliases = data.get("aliases")
+    if not ensure_list_of_strings(aliases):
+        errors.append(f"{path}: 'aliases' must be a non-empty list of strings")
+
+    part = data.get("part_of_speech")
+    if part not in ALLOWED_PARTS_OF_SPEECH:
+        errors.append(f"{path}: part_of_speech '{part}' is invalid")
+
+    short_def = data.get("short_def")
+    if isinstance(short_def, str):
+        word_count = count_words(short_def)
+        if word_count > MAX_SHORT_DEF_WORDS:
+            errors.append(
+                f"{path}: short_def has {word_count} words (max {MAX_SHORT_DEF_WORDS})"
+            )
+    else:
+        errors.append(f"{path}: 'short_def' must be a string")
+
+    long_def = data.get("long_def")
+    if isinstance(long_def, str):
+        word_count = count_words(long_def)
+        if word_count < MIN_LONG_DEF_WORDS or word_count > MAX_LONG_DEF_WORDS:
+            errors.append(
+                f"{path}: long_def has {word_count} words (expected {MIN_LONG_DEF_WORDS}-{MAX_LONG_DEF_WORDS})"
+            )
+    else:
+        errors.append(f"{path}: 'long_def' must be a string")
+
+    audiences = data.get("audiences")
+    if isinstance(audiences, dict):
+        for audience in ("exec", "engineer"):
+            value = audiences.get(audience)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{path}: audiences.{audience} must be a non-empty string")
+    else:
+        errors.append(f"{path}: 'audiences' must be a mapping with exec/engineer keys")
+
+    examples = data.get("examples")
+    if isinstance(examples, dict):
+        for key in ("do", "dont"):
+            entries = examples.get(key)
+            if not ensure_list_of_strings(entries):
+                errors.append(f"{path}: examples.{key} must include at least one example")
+    else:
+        errors.append(f"{path}: 'examples' must define 'do' and 'dont' lists")
+
+    governance = data.get("governance")
+    if isinstance(governance, dict):
+        tags = governance.get("nist_rmf_tags")
+        if tags is not None and not ensure_list_of_strings(tags, allow_empty=False):
+            errors.append(f"{path}: governance.nist_rmf_tags must be a list of strings")
+        notes = governance.get("risk_notes")
+        if notes is not None and not isinstance(notes, str):
+            errors.append(f"{path}: governance.risk_notes must be a string when provided")
+    else:
+        errors.append(f"{path}: 'governance' must be a mapping")
+
+    relationships = data.get("relationships")
+    if isinstance(relationships, dict):
+        for rel_key in ("broader", "narrower", "related"):
+            rel_value = relationships.get(rel_key)
+            if rel_value is not None and not ensure_list_of_strings(rel_value, allow_empty=True):
+                errors.append(f"{path}: relationships.{rel_key} must be a list of strings")
+    else:
+        errors.append(f"{path}: 'relationships' must be a mapping")
+
+    citations = data.get("citations")
+    if isinstance(citations, list) and citations:
+        for idx, citation in enumerate(citations):
+            if not isinstance(citation, dict):
+                errors.append(f"{path}: citation #{idx + 1} must be a mapping")
+                continue
+            if not isinstance(citation.get("source"), str) or not citation["source"].strip():
+                errors.append(f"{path}: citation #{idx + 1} missing 'source'")
+            url = citation.get("url")
+            if not isinstance(url, str) or not url.startswith("http"):
+                errors.append(f"{path}: citation #{idx + 1} has invalid 'url'")
+    else:
+        errors.append(f"{path}: 'citations' must contain at least one entry")
+
+    license_value = data.get("license")
+    if license_value not in ALLOWED_LICENSES:
+        errors.append(f"{path}: license '{license_value}' must be one of {sorted(ALLOWED_LICENSES)}")
+
+    status = data.get("status")
+    if status not in ALLOWED_STATUSES:
+        errors.append(f"{path}: status '{status}' is not valid")
+
+    last_reviewed = data.get("last_reviewed")
+    if isinstance(last_reviewed, str):
+        try:
+            datetime.fromisoformat(last_reviewed)
+        except ValueError:
+            errors.append(f"{path}: last_reviewed '{last_reviewed}' is not ISO date (YYYY-MM-DD)")
+    else:
+        errors.append(f"{path}: 'last_reviewed' must be an ISO date string")
+
+    return errors
+
+
+def iter_term_files(data_dir: Path) -> Iterable[Path]:
+    return sorted(data_dir.glob("*.yml"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate glossary term files")
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("data/terms"),
+        help="Directory containing YAML term files",
+    )
+    args = parser.parse_args(argv)
+
+    if not SCHEMA_PATH.exists():
+        print(f"Schema not found at {SCHEMA_PATH}", file=sys.stderr)
+        return 1
+
+    required_fields = load_required_fields()
+    term_files = list(iter_term_files(args.data_dir))
+    if not term_files:
+        print(f"No term files found in {args.data_dir}", file=sys.stderr)
+        return 1
+
+    all_errors: List[str] = []
+    for file_path in term_files:
+        all_errors.extend(validate_file(file_path, required_fields))
+
+    if all_errors:
+        print("Validation failed:", file=sys.stderr)
+        for message in all_errors:
+            print(f" - {message}", file=sys.stderr)
+        return 1
+
+    print(f"Validated {len(term_files)} term(s) successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/docs/contributing.md
+++ b/site/docs/contributing.md
@@ -1,0 +1,13 @@
+# Contributing
+
+Thank you for helping expand the glossary. Follow these steps to get started:
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies with `pip install -r requirements.txt`.
+3. Create or update a YAML file under `data/terms/`.
+4. Run `make validate` to ensure schema and lint checks pass.
+5. Regenerate JSON outputs using `python scripts/build_index.py` (optional but recommended).
+6. Open a pull request using the provided template.
+
+See the root-level [CONTRIBUTING.md](../CONTRIBUTING.md) for detailed guidance,
+including formatting rules, review checklist, and citation requirements.

--- a/site/docs/data-model.md
+++ b/site/docs/data-model.md
@@ -1,0 +1,53 @@
+# Data Model
+
+All glossary entries follow the schema defined in `schema/term.schema.json`. Each
+YAML file under `data/terms/` captures a single concept and includes metadata for
+cross-team alignment.
+
+```yaml
+term: "example"
+aliases:
+  - "synonym"
+part_of_speech: "noun"
+short_def: "≤40 word summary."
+long_def: >-
+  120–200 word explanation that provides history, context, and operational
+  considerations.
+audiences:
+  exec: "Business-ready framing."
+  engineer: "Technical framing."
+examples:
+  do:
+    - "What good practice looks like."
+  dont:
+    - "What to avoid."
+governance:
+  nist_rmf_tags:
+    - "tag"
+  risk_notes: "Key compliance considerations."
+relationships:
+  broader:
+    - "parent term"
+  narrower:
+    - "child term"
+  related:
+    - "peer term"
+citations:
+  - source: "Credible reference"
+    url: "https://example.com"
+license: "CC BY-SA 4.0"
+status: "draft"
+last_reviewed: "2024-01-01"
+```
+
+## Validation rules
+
+- `short_def` must be **40 words or fewer**.
+- `long_def` must fall between **80 and 220 words**.
+- Executive and engineering variants are mandatory.
+- Provide at least one example in each of the `do` and `dont` lists.
+- Cite sources with URLs to reputable glossaries, standards, or academic
+  references.
+
+Run `make validate` locally to confirm entries match both the JSON Schema and
+custom rules.

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -1,0 +1,31 @@
+# AI Glossary
+
+Welcome to the living glossary for artificial intelligence teams. The project
+harmonizes terminology used across product, engineering, and governance
+workstreams while keeping sourcing and risk context close to every definition.
+
+## Why it exists
+
+- **Shared language:** reduce confusion when policy, product, and engineering
+  groups describe the same concept with different words.
+- **Structured content:** every entry is stored as YAML so it can be reused in
+  docs, APIs, or automated reviews.
+- **Governance aware:** terms include NIST AI RMF tags, risk notes, and
+  lifecycle status so compliance teams can trace the meaning.
+
+## What you get today
+
+- Seed entries for high-impact concepts like hallucination, retrieval-augmented
+  generation, and quantization.
+- A validation pipeline that enforces schema compliance, definition length, and
+  presence of audience-specific explanations.
+- JSON outputs (`build/glossary.json`, `build/search-index.json`) that downstream
+  systems or chatbots can ingest.
+
+## Next steps
+
+- Expand to 50+ core LLM, ML Ops, and governance terms.
+- Publish the static site via GitHub Pages.
+- Stand up the lightweight API for programmatic access.
+
+Ready to contribute? Check out the [Contribution guide](contributing.md).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -1,0 +1,40 @@
+site_name: AI Glossary
+site_description: A cross-functional, citation-backed vocabulary for AI teams.
+site_url: https://example.com/ai-glossary
+repo_url: https://github.com/your-org/ai-glossary
+repo_name: your-org/ai-glossary
+copyright: "© 2024 AI Glossary contributors"
+
+nav:
+  - Home: index.md
+  - Data Model: data-model.md
+  - Contributing: contributing.md
+
+theme:
+  name: material
+  features:
+    - navigation.tracking
+    - content.action.edit
+    - toc.integrate
+  palette:
+    - scheme: default
+      primary: blue
+      accent: deep orange
+  icon:
+    logo: material/book-outline
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - footnotes
+  - toc:
+      permalink: true
+  - tables
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/your-org/ai-glossary
+      name: GitHub


### PR DESCRIPTION
## Summary
- scaffold the repository with licenses, governance docs, contribution guidelines, and CI workflows
- define a JSON schema and seed YAML entries for initial glossary terms backed by a custom dependency-free YAML loader
- add build/validation scripts, MkDocs site skeleton, and a FastAPI stub that serve structured glossary data

## Testing
- make validate
- python scripts/build_index.py --data-dir data/terms --output-dir build
- cd site && mkdocs build --strict *(fails: mkdocs not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc16314788322b7d690e6a8ceeeeb