### PR TITLE
Fix validate script compatibility with older Python versions

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -7,7 +7,7 @@ import json
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 CURRENT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = CURRENT_DIR.parent
@@ -197,7 +197,7 @@ def iter_term_files(data_dir: Path) -> Iterable[Path]:
     return sorted(data_dir.glob("*.yml"))
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Validate glossary term files")
     parser.add_argument(
         "--data-dir",


### PR DESCRIPTION
## Summary
- import Optional so we can express the CLI argument typing without Python 3.10 unions
- change the validate entry point to use Optional[List[str]] for compatibility with Python 3.9 environments

## Testing
- make validate
- pytest tests/test_yaml_parser.py -q

------
https://chatgpt.com/codex/tasks/task_e_68da8bdf6f50832296c53bd7a147a8f2